### PR TITLE
[MER-636] Fixed XSS vulnerability on activity bank page.

### DIFF
--- a/lib/oli_web/templates/activity_bank/index.html.eex
+++ b/lib/oli_web/templates/activity_bank/index.html.eex
@@ -7,7 +7,7 @@
 <div id="editor" class="container"/>
 
 <script>
-
-  const params = <%= raw(Jason.encode!(@context)) %>;
+  const encodedParams = "<%= json_escape(@context) %>";
+  const params = JSON.parse(decodeURIComponent(encodedParams));
   window.oliMountApplication(document.getElementById('editor'), params);
 </script>

--- a/lib/oli_web/views/activity_bank_view.ex
+++ b/lib/oli_web/views/activity_bank_view.ex
@@ -3,6 +3,36 @@ defmodule OliWeb.ActivityBankView do
 
   alias OliWeb.Router.Helpers, as: Routes
 
+  @doc """
+
+  Will Jason.encode! and URI.encode the input to return a version suitable for use to output
+  within a <script> tag of a template.
+
+  Within a template, when we have user-supplied data, it lets us more safely do a
+
+  <script>
+   const encodedParams = "<%= json_escape(@context) %>";
+   const params = JSON.parse(decodeURIComponent(encodedParams));
+  </script>
+
+  instead of an unsafe:
+
+  <script>
+   const params = <%= raw( Jason.encode!(@context) ) %>;
+  </script>
+
+  """
+  def json_escape(input) do
+    {:safe,
+     input
+     |> Jason.encode!()
+     |> URI.encode(&json_char_escaped/1)}
+  end
+
+  # we're not going to encode a few characters, to make our string a little smaller and more readable
+  defp json_char_escaped(c) when c in [32, ?:, ?{, ?}], do: true
+  defp json_char_escaped(c), do: URI.char_unescaped?(c)
+
   def render_activity(activity, activity_type, section_slug) do
     tag = activity_type.authoring_element
 

--- a/test/oli_web/views/activity_bank_view_test.exs
+++ b/test/oli_web/views/activity_bank_view_test.exs
@@ -1,0 +1,25 @@
+defmodule OliWeb.ActivityBankViewTest do
+  use OliWeb.ConnCase, async: true
+
+  describe "activity_bank_view" do
+    import OliWeb.ActivityBankView
+
+    test "Escape a JS JSON string with a potential XSS attack" do
+      result = json_escape(%{evilParam: "</script>"})
+      assert result == {:safe, "{%22evilParam%22:%22%3C/script%3E%22}"}
+    end
+
+    test "Does not cause an XSS vulnerability", %{conn: conn} do
+      testConn = conn |> put_private(:phoenix_endpoint, OliWeb.Endpoint)
+
+      result =
+        Phoenix.View.render_to_string(OliWeb.ActivityBankView, "index.html",
+          conn: testConn,
+          scripts: [],
+          context: %{evilParam: "</script>"}
+        )
+
+      assert result =~ "const encodedParams = \"{%22evilParam%22:%22%3C/script%3E%22}\";"
+    end
+  end
+end


### PR DESCRIPTION
WIP: Don't merge

There was a potential XSS vulnerability when entering a learning objective and then viewing the activity-bank page.

Steps to reproduce:

Login as an authoring user
Create a course or select existing
Navigate to “Create -> Objectives”
Type a payload and click ‘Create’ to save it:
</script><script>alert(document.location)</script><!--
Navigate to “Create -> Activity Bank”
Observe executed JavaScript as an alert pop-up.
This was caused by the way we were passing params to the embedded react app on that page since @context contained some user-supplied data.

const params = <%= raw(Jason.encode!(@context)) %>;
I tried a few different ways of encoding the data:

Manually encoding each value - this turned out pretty messy due to the deeper hierarchy of data passed.
Using Phoenix.HTML.html_escape - this escapes characters you really want to preserve, like quotes. Tried to be clever with un-escaping those, but didn't feel right.
In the end, went with a URI encoded plain string that the client page would then parse out. It has the benefit of always working, being straight-forward, and easily readable. Downside of having to do a JSON.parse in JS land.