### PR TITLE
Example of a sandbox policy

### DIFF
--- a/assets/src/components/parts/janus-capi-iframe/ExternalActivity.tsx
+++ b/assets/src/components/parts/janus-capi-iframe/ExternalActivity.tsx
@@ -1077,6 +1077,7 @@ const ExternalActivity: React.FC<PartComponentProps<CapiIframeModel>> = (props) 
       title={title}
       src={frameSrc}
       scrolling={scrolling}
+      sandbox="allow-downloads allow-forms allow-scripts"
     />
   ) : null;
 };


### PR DESCRIPTION
This is just some example code showing one possible solution to securing iframes and should not be merged since I have no idea what capabilities all our embeds require.

See:
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-sandbox
